### PR TITLE
Better Error Message

### DIFF
--- a/lib/authority/security_violation.rb
+++ b/lib/authority/security_violation.rb
@@ -9,7 +9,7 @@ module Authority
     end
 
     def message
-      "#{@user} is not authorized to #{@action} this resource: #{@resource}"
+      "#{@user.class.name} #{@user.id} is not authorized to #{@action} this resource: #{@resource}"
     end
   end
 end

--- a/spec/authority_spec.rb
+++ b/spec/authority_spec.rb
@@ -121,7 +121,7 @@ describe Authority do
     end
 
     it "uses them all in its message" do
-      expect(security_violation.message).to eq("#{user} is not authorized to #{action} this resource: #{resource}")
+      expect(security_violation.message).to eq("#{user.class.name} #{user.id} is not authorized to #{action} this resource: #{resource}")
     end
 
   end


### PR DESCRIPTION
String interpolation uses `to_s` method, and shows a message that is not very informative:
```
<User:0x00007fe1962eb380> is not authorized to ...
```
